### PR TITLE
Fix SplashScreen on Android

### DIFF
--- a/PUAMapp/SplashScreen.js
+++ b/PUAMapp/SplashScreen.js
@@ -14,9 +14,9 @@ export default class SpalshScreen extends Component {
 
      }
 
-    static navigationOptions = ({ navigation }) => ({
-    headerStyle:{ position: 'absolute', backgroundColor: 'transparent', zIndex: 100, top: 0, left: 0, right: 0, borderBottomColor: 'transparent' }
-    });
+    static navigationOptions = {
+      header: null
+    };
 
     render () {
 


### PR DESCRIPTION
The header was transparent but the bottom border was still visible. The header is now gone.