### PR TITLE
Mural ordering

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -129,11 +129,17 @@ def fireput():
         global count
         count += 1
         uuidtoken = uuid.uuid4()
+        
+        # the new mural's index = 1 + the number of existing murals
+        murals = firebase.get('/', 'murals')
+        index = 1 + len(murals)
+        
         putData = { 'Photo' : form.photo.data, 'Lat' : form.lat.data,
                     'Long' : form.longitude.data, 'Artist' : form.artist.data,
                     'Title' : form.title.data, 'Month' : form.month.data,
                     'Year' : form.year.data, 'Description' : form.description.data,
-                    'Medium' : form.medium.data, 'uuid' : str(uuidtoken) }
+                    'Medium' : form.medium.data, 'uuid' : str(uuidtoken),
+                    'Index': index }
         firebase.put('/murals', uuidtoken, putData)
         return render_template('form-result.html', putData=putData)
     return render_template('My-Form.html', form=form)

--- a/flask/app.py
+++ b/flask/app.py
@@ -217,23 +217,24 @@ def delete_mural():
     
     # reindex all the murals
     murals = firebase.get('/', 'murals')
-    key = request.form["muralid"]
+    key = str(request.form["muralid"])
     removed_index = murals[key]["Index"]
     
     # if a mural's index is > removed_index, decrement the index
     for m in murals:
-        if murals[m]["Index"] > index:
+        if murals[m]["Index"] > removed_index:
             murals[m]["Index"] = murals[m]["Index"] - 1
     
     # remove the mural
     if key in murals: del murals[key]
     
     # update firebase
-    firebase.put('/murals', murals)
-	
-    # firebase.delete('/murals', str(request.form["muralid"]))
+    firebase.delete('/murals', key)
+    for uuid in murals:
+        firebase.put('/murals', uuid, murals[uuid])
     
-	return redirect(url_for('fireget'), code=302)
+    
+    return redirect(url_for('fireget'), code=302)
 
 @app.route('/api/change_mural_index', methods = ['POST'])
 @requires_auth
@@ -278,7 +279,9 @@ def change_mural_index():
     fromMural["Index"] = toMuralIndex
     toMural["Index"] = fromMuralIndex
     
-    # TODO update firebase
+    # update firebase
+    firebase.put('/murals', fromMural["uuid"], fromMural)
+    firebase.put('/murals', toMural["uuid"], toMural)
     
     print "fromMural", fromMural
     print "toMural", toMural

--- a/flask/app.py
+++ b/flask/app.py
@@ -164,7 +164,8 @@ def fireedit():
                     'Long' : form.longitude.data, 'Artist' : form.artist.data,
                     'Title' : form.title.data, 'Month' : form.month.data,
                     'Year' : form.year.data, 'Description' : form.description.data,
-                    'Medium' : form.medium.data, 'uuid' : str(muralid) }
+                    'Medium' : form.medium.data, 'uuid' : str(muralid),
+                    'Index': mural["Index"] }
         print putData
         firebase.delete('/murals', str(muralid))
         print "deleted"

--- a/flask/app.py
+++ b/flask/app.py
@@ -214,7 +214,25 @@ def fireget():
 @app.route('/api/delete_mural', methods = ['GET', 'POST'])
 @requires_auth
 def delete_mural():
-	firebase.delete('/murals', str(request.form["muralid"]))
+    
+    # reindex all the murals
+    murals = firebase.get('/', 'murals')
+    key = request.form["muralid"]
+    removed_index = murals[key]["Index"]
+    
+    # if a mural's index is > removed_index, decrement the index
+    for m in murals:
+        if murals[m]["Index"] > index:
+            murals[m]["Index"] = murals[m]["Index"] - 1
+    
+    # remove the mural
+    if key in murals: del murals[key]
+    
+    # update firebase
+    firebase.put('/murals', murals)
+	
+    # firebase.delete('/murals', str(request.form["muralid"]))
+    
 	return redirect(url_for('fireget'), code=302)
 
 @app.route('/api/change_mural_index', methods = ['POST'])

--- a/flask/templates/disp-all.html
+++ b/flask/templates/disp-all.html
@@ -3,12 +3,53 @@
 {% block page_content %}
 <body>
 <table style="width:80%">
-<tr><th>Title</th><th>Artist</th><th>Photo</th><th>Latitude</th><th>Longitude</th><th>Month</th><th>Year</th></tr>
-
-{% for m in murals %}
 <tr>
-<td>{{ murals[m].Title }}</td> <td>{{ artists[murals[m].Artist].name }}</td> <td>{{ murals[m].Photo }}</td><td>{{ murals[m].Lat }}</td> <td>{{ murals[m].Long }}</td>  <td>{{ murals[m].Month }}</td> <td>{{ murals[m].Year }}</td>
-	<td><form action="{{url_for('delete_mural')}}" method = "POST"> <input type = "hidden" name = "muralid" value = "{{ m }}"><button type="submit" name="del">Delete</button></form></td><td><form action="{{url_for('fireedit')}}" method = "GET"> <input type = "hidden" name = "muralid" value = "{{ m }}"><button type="submit" name="edit">Edit</button></form></td>
+    <th>Title</th>
+    <th>Artist</th>
+    <th>Photo</th>
+    <th>Latitude</th>
+    <th>Longitude</th>
+    <th>Month</th>
+    <th>Year</th>
+    <th>Index</th>
+</tr>
+
+{% for mural in murals %}
+<tr>
+    <td>{{ mural.Title }}</td> 
+    <td>{{ artists[mural.Artist].name }}</td> 
+    <td>{{ mural.Photo }}</td>
+    <td>{{ mural.Lat }}</td> 
+    <td>{{ mural.Long }}</td>  
+    <td>{{ mural.Month }}</td> 
+    <td>{{ mural.Year }}</td>
+    <td>{{ mural.Index }}</td>
+    <td>
+        <form action="{{url_for('change_mural_index')}}" method = "POST">
+            <input type = "hidden" name = "muralid" value = "{{ mural['uuid'] }}">
+            <input type = "hidden" name = "upOrDown" value = "UP">
+            <button type="submit" name="change">UP</button>
+        </form>
+    </td>
+    <td>
+        <form action="{{url_for('change_mural_index')}}" method = "POST">
+            <input type = "hidden" name = "muralid" value = "{{ mural['uuid'] }}">
+            <input type = "hidden" name = "upOrDown" value = "DOWN">
+            <button type="submit" name="change">DOWN</button>
+        </form>
+    </td>
+	<td>
+        <form action="{{url_for('delete_mural')}}" method = "POST">
+            <input type = "hidden" name = "muralid" value = "{{ mural['uuid'] }}">
+            <button type="submit" name="del">Delete</button>
+        </form>
+    </td>
+    <td>
+        <form action="{{url_for('fireedit')}}" method = "GET">
+            <input type = "hidden" name = "muralid" value = "{{ mural['uuid'] }}">
+            <button type="submit" name="edit">Edit</button>
+        </form>
+    </td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
- upon adding a mural, it's Index is 1 + number of existing murals
- can move Index up and down from the /api/get page
- upon deleting a mural, all mural indices higher than the index get decremented (--)

@airwayneeee @chris-anderson67 

Now the /api/get page breaks when there exists murals in the firebase db without an Index
