### PR TITLE
Don't show logo on splash screen for Android, center the loading circle

### DIFF
--- a/PUAMapp/App.js
+++ b/PUAMapp/App.js
@@ -24,9 +24,9 @@ import { getMurals, getArtists } from "./redux";
 import { Provider } from "react-redux";
 import { store } from "./redux";
 
-// import Sentry from 'sentry-expo';
-// import configString from "./sentry";
-// Sentry.config(configString.publicDSN).install();
+import Sentry from 'sentry-expo';
+import configString from "./sentry";
+Sentry.config(configString.publicDSN).install();
 
 class AppInner extends React.Component {
   constructor(props) {

--- a/PUAMapp/App.js
+++ b/PUAMapp/App.js
@@ -24,9 +24,9 @@ import { getMurals, getArtists } from "./redux";
 import { Provider } from "react-redux";
 import { store } from "./redux";
 
-import Sentry from 'sentry-expo';
-import configString from "./sentry";
-Sentry.config(configString.publicDSN).install();
+// import Sentry from 'sentry-expo';
+// import configString from "./sentry";
+// Sentry.config(configString.publicDSN).install();
 
 class AppInner extends React.Component {
   constructor(props) {

--- a/PUAMapp/SplashScreen.js
+++ b/PUAMapp/SplashScreen.js
@@ -13,7 +13,11 @@ import {
   Dimensions
 } from "react-native";
 import { NavigationActions } from "react-navigation";
-
+  
+  function isIOS() {
+      return Platform.OS === "ios";
+  }
+  
   function isIphoneX() {
     const dimen = Dimensions.get("window");
     return (
@@ -67,16 +71,19 @@ export default class SpalshScreen extends Component {
   render() {
     return (
       <View style={{ flex: 1, backgroundColor: "#ffffff" }}>
-        <Image
-          style={{
-            flex: 1,
-            resizeMode: "contain",
-            position: "absolute",
-            height: "100%",
-            width: "100%"
-          }}
-          source={require("./assets/images/splash-background.png")}
-        />
+        {
+            isIOS() && 
+            <Image
+              style={{
+                flex: 1,
+                resizeMode: "contain",
+                position: "absolute",
+                height: "100%",
+                width: "100%"
+              }}
+              source={require("./assets/images/splash-background.png")}
+            />
+        }
         <View style={[styles.container, styles.horizontal]}>
           <ActivityIndicator size="large" color="gray" />
         </View>
@@ -94,6 +101,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-around",
     padding: 100,
-    marginTop: isIphoneX() ? "130%" : "120%"
+    // if iphoneX, 130%, else if iOS, 120%, else (if android) 0%
+    marginTop: isIphoneX() ? "130%" : (isIOS() ? "120%" : "0%")
   }
 });


### PR DESCRIPTION

The purpose of this is because on Android, the static image splash would appear
then fade out and then the actual splash screen would reappear.

With this change, the user (only android) will see the logo, see it fade out, and then see
the loading circle.

@chris-anderson67 

Note: please don't merge yet. I had to comment out the sentry stuff for this to run locally. We should sort that out first.
