### PR TITLE
Fix Tour Bugs

### DIFF
--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -45,8 +45,7 @@ export default class ExplorePage extends React.Component {
           headerLeft: (
             <TouchableOpacity
               style={{ top: 30, left: -25, padding: 40 }}
-              onPress={() => {self.props.screenProps.falseFromGallery() 
-                              navigation.dispatch(NavigationActions.back())}}
+              onPress={() => {navigation.dispatch(NavigationActions.back())}}
             >
               <View
                 style={{
@@ -86,6 +85,11 @@ export default class ExplorePage extends React.Component {
           headerTintColor: "white",
           headerStyle: { backgroundColor: pink }
         };
+  }
+  
+  // Returns true if we came from the gallery's mural info page ("see mural on map" button)
+  didComeFromGallery() {
+    return (this.props.navigation.state.params && this.props.navigation.state.params.muralID);
   }
   
   renderImages() {
@@ -139,7 +143,6 @@ export default class ExplorePage extends React.Component {
             // See if the currMarker corresponds to a mural
         if (this.props.navigation.state.params && this.props.navigation.state.params.muralID) {
             this.toggleTour();
-            this.props.screenProps.trueFromGallery();
 
             this.markers[this.props.navigation.state.params.muralID].showCallout();
             return;
@@ -336,7 +339,7 @@ export default class ExplorePage extends React.Component {
             onPress={()=>this.toggleTour()}
             >  </Button>
             </View>
-            : this.props.screenProps.fromGallery ?
+            : this.didComeFromGallery() ?
             <View></View> :
             <Button 
             title="start tour"

--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -110,10 +110,6 @@ export default class ExplorePage extends React.Component {
       title = murals[key]["Title"];
       artistName = artists[murals[key]["Artist"]]["name"];
 
-      setRefLambda = (function (ref) {
-        this.calloutToMakeVisible = ref
-      }).bind(this);
-      
       return (
         <MapView.Marker
           key={i}
@@ -122,8 +118,6 @@ export default class ExplorePage extends React.Component {
           coordinate={{ latitude: lat, longitude: long }}
           pinColor={pink}
           ref = {(ref) => this.markers[key] = ref}
-          //{key == defaultMuralID ? setRefLambda : null} 
-
           onCalloutPress={() => {
             navigate("MuralInfoPage", {
               mural: murals[key],
@@ -200,36 +194,6 @@ export default class ExplorePage extends React.Component {
 
     }
 
-    getCurrCoordsLat(){
-      murals = this.props.screenProps.murals || {}
-      Lat = 42.518217
-
-
-        Object.keys(murals).map((key,i) =>{
-
-            if (murals[key]["Index"] == this.props.screenProps.currMarker ){
-              Lat = parseFloat(murals[key]["Lat"]);
-              return Lat;
-            }
-          })
-      
-      return Lat;
-
-    }
-
-    getCurrCoordsLong(){
-      murals = this.props.screenProps.murals || {}
-      Lon = -70.891919
-     
-      Object.keys(murals).map((key,i) =>{
-
-          if (murals[key]["Index"] == this.props.screenProps.currMarker ){
-            Lon = parseFloat(murals[key]["Long"]);
-            return Lon;
-          }
-        })
-      return Lon;
-    }
 
     tourPrev() {
       if(this.props.screenProps.currMarker == 1){

--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -26,6 +26,9 @@ import  MapView, {Polyline} from 'react-native-maps';
 // This won't do anything if the permission is already granted.
 Permissions.askAsync(Permissions.LOCATION);
 
+// Note: For all intents and purposes, "mural key" is the same as "mural id".
+// But "mural index" does not refer to either of those things, it only refers
+// to a mural's order in the tour.
 export default class ExplorePage extends React.Component {
     constructor(props) {
         super(props);
@@ -92,7 +95,10 @@ export default class ExplorePage extends React.Component {
     return (this.props.navigation.state.params && this.props.navigation.state.params.muralID);
   }
   
-  // Logic for determining which mural should currently be shown to the user
+  // Logic for determining which mural should currently be shown to the user.
+  // If we came from the gallery -> mural info page, show that mural.
+  // If we're on a tour, show the mural of the index we're currently at
+  // Otherwise return undefined.
   currentMuralID() {
     if (this.didComeFromGallery()) {
       return this.props.navigation.state.params.muralID;
@@ -220,12 +226,9 @@ export default class ExplorePage extends React.Component {
             longitudeDelta: initialDelta
         };
         
-        // Determine which region we WANT to go to.
         region = undefined;
-        
         murals = this.props.screenProps.murals || {};
 
-        
         if (this.currentMuralID()) {
           mural = murals[this.currentMuralID()];
           region = {

--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -33,9 +33,7 @@ export default class ExplorePage extends React.Component {
         initialLat = 42.518217;
         initialLong = -70.891919;
         initialDelta = 0.005;
-        
-        this.state = { markers : [],
-                        };
+        this.markers = []
 
       this.tourNext = this.tourNext.bind(this);
  }
@@ -119,7 +117,7 @@ export default class ExplorePage extends React.Component {
           description={artistName}
           coordinate={{ latitude: lat, longitude: long }}
           pinColor={pink}
-          ref = {(ref) => this.state.markers[key] = ref}
+          ref = {(ref) => this.markers[key] = ref}
           //{key == defaultMuralID ? setRefLambda : null} 
 
           onCalloutPress={() => {
@@ -143,7 +141,7 @@ export default class ExplorePage extends React.Component {
             this.toggleTour();
             this.props.screenProps.trueFromGallery();
 
-            this.state.markers[this.props.navigation.state.params.muralID].showCallout();
+            this.markers[this.props.navigation.state.params.muralID].showCallout();
             return;
             }
             
@@ -159,13 +157,13 @@ export default class ExplorePage extends React.Component {
                       }
 
                   });
-      if (this.state.markers) {
-                  this.state.markers[markerKey].showCallout();
+      if (this.markers) {
+                  this.markers[markerKey].showCallout();
         }
     
   }
      if (this.props.navigation.state.params && this.props.navigation.state.params.muralID) {
-      this.state.markers[this.props.navigation.state.params.muralID].showCallout();
+      this.markers[this.props.navigation.state.params.muralID].showCallout();
 
     }
 
@@ -177,7 +175,7 @@ export default class ExplorePage extends React.Component {
       murals = this.props.screenProps.murals || {};
       if (this.props.screenProps.tourStarted){
         Object.keys(murals).map((key,i) =>{
-          this.state.markers[key].hideCallout();
+          this.markers[key].hideCallout();
         });
         
       }

--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -30,9 +30,9 @@ export default class ExplorePage extends React.Component {
     constructor(props) {
         super(props);
         self = this; 
-        initialLat = 42.518217;
-        initialLong = -70.891919;
-        initialDelta = 0.005;
+
+        // Where we will store the refs to all the markers
+        // This is necessary because showing and hiding a callout must be done imperatively.
         this.markers = []
 
       this.tourNext = this.tourNext.bind(this);
@@ -92,6 +92,26 @@ export default class ExplorePage extends React.Component {
     return (this.props.navigation.state.params && this.props.navigation.state.params.muralID);
   }
   
+  // Logic for determining which mural should currently be shown to the user
+  currentMuralID() {
+    if (this.didComeFromGallery()) {
+      return this.props.navigation.state.params.muralID;
+    }
+    else if (this.props.screenProps.tourStarted) {
+      currMarkerIndex = this.props.screenProps.currMarker
+      murals = this.props.screenProps.murals || {};
+
+      for (muralKey in murals) {
+        if (murals[muralKey]["Index"] == currMarkerIndex) {
+          return muralKey;
+        }
+      }
+    }
+    
+    return undefined;
+    
+  }
+  
   renderMarkers() {
     const { navigate } = this.props.navigation;
 
@@ -133,38 +153,12 @@ export default class ExplorePage extends React.Component {
   
   goToMural() {
     murals = this.props.screenProps.murals || {};
-    if (this.props.screenProps.tourStarted) {
-            // See if the currMarker corresponds to a mural
-        if (this.props.navigation.state.params && this.props.navigation.state.params.muralID) {
-            this.toggleTour();
-
-            this.markers[this.props.navigation.state.params.muralID].showCallout();
-            return;
-            }
-            
-            Lat = 0
-            Lon = 0
-            markerKey =0
-            Object.keys(murals).map((key,i) =>{
-                    console.log("306")
-                    if (murals[key]["Index"] == this.props.screenProps.currMarker){
-                      Lat = parseFloat(murals[key]["Lat"]);
-                      Lon = parseFloat(murals[key]["Long"]);
-                      markerKey = key;
-                      }
-
-                  });
-      if (this.markers) {
-                  this.markers[markerKey].showCallout();
-        }
     
+      if (this.markers && this.currentMuralID()) {
+        this.markers[this.currentMuralID()].showCallout();
+      }
   }
-     if (this.props.navigation.state.params && this.props.navigation.state.params.muralID) {
-      this.markers[this.props.navigation.state.params.muralID].showCallout();
 
-    }
-
-  }
 
     toggleTour() {
 
@@ -185,15 +179,11 @@ export default class ExplorePage extends React.Component {
     tourNext () {
 
         this.props.screenProps.changeMarker();
-        
-       
-      
         if( this.props.screenProps.currMarker == Object.keys(this.props.screenProps.murals).length - 1){
             this.toggleTour();
         }
 
     }
-
 
     tourPrev() {
       if(this.props.screenProps.currMarker == 1){
@@ -222,50 +212,16 @@ export default class ExplorePage extends React.Component {
         
         murals = this.props.screenProps.murals || {};
 
-        // If we came from the MuralInfoPage
-        if (this.props.navigation.state.params && this.props.navigation.state.params.muralID) {
-            key = this.props.navigation.state.params.muralID;
         
-            region = {
-              latitude: parseFloat(murals[key]["Lat"]),
-              longitude: parseFloat(murals[key]["Long"]),
-              latitudeDelta: .001,
-              longitudeDelta: .001,
-            }
+        if (this.currentMuralID()) {
+          mural = murals[this.currentMuralID()];
+          region = {
+            longitude: mural["Long"],
+            latitude: mural["Lat"],
+            longitudeDelta: .001,
+            latitudeDelta: .001
+          };
         }
-        
-        // If we're on a tour
-        else if (this.props.screenProps.tourStarted) {
-            console.log("299", this.props.screenProps.currMarker)
-            // See if the currMarker corresponds to a mural
-            
-            Lat = 0
-            Lon = 0
-      
-
-            Object.keys(murals).map((key,i) =>{
-                    console.log("306")
-                    if (murals[key]["Index"] == this.props.screenProps.currMarker){
-                      Lat = parseFloat(murals[key]["Lat"]);
-                      Lon = parseFloat(murals[key]["Long"]);
-                     
-                      }
-
-                  });
-            
-            if (Lat != 0 && Lon != 0) {
-                console.log("316")
-                region = {
-                   latitude: Lat,
-                   longitude: Lon,
-                   latitudeDelta: .001,
-                   longitudeDelta: .001,
-                 } 
-                  
-            }
-            
-        }
-
         else {
           region = initialRegion
         }

--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -22,10 +22,6 @@ import MapViewDirections from 'react-native-maps-directions';
 import  MapView, {Polyline} from 'react-native-maps';
 
 
-
-
-
-
 // This triggers asking the user for location permissions.
 // This won't do anything if the permission is already granted.
 Permissions.askAsync(Permissions.LOCATION);
@@ -41,27 +37,9 @@ export default class ExplorePage extends React.Component {
         this.state = { markers : [],
                         };
 
-      this.onRegionChange = this.onRegionChange.bind(this);
       this.tourNext = this.tourNext.bind(this);
  }
 
-  getInitialState() {
-    initialLat = 42.518217;
-    initialLong = -70.891919;
-    initialDelta = 0.005;
-    return {
-      region: {
-        latitude: initialLat,
-        longitude: initialLong ,
-        latitudeDelta: initialDelta,
-        longitudeDelta: initialDelta,
-      },
-    };
-  }
-
-  onRegionChange(region) {
-    this.setState({ region });
-  }
 
   static navigationOptions = ({ navigation}) => {
     return Platform.OS === "ios"

--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -92,7 +92,7 @@ export default class ExplorePage extends React.Component {
     return (this.props.navigation.state.params && this.props.navigation.state.params.muralID);
   }
   
-  renderImages() {
+  renderMarkers() {
     const { navigate } = this.props.navigation;
 
     murals = this.props.screenProps.murals || {};
@@ -319,7 +319,7 @@ export default class ExplorePage extends React.Component {
               region =  {region}
               onLayout = {this.goToMural.bind(this)}
                >
-              {this.renderImages()}
+              {this.renderMarkers()}
             
            
             </AnimatedMapView>

--- a/PUAMapp/ExplorePage.js
+++ b/PUAMapp/ExplorePage.js
@@ -29,6 +29,7 @@ import  MapView, {Polyline} from 'react-native-maps';
 // This triggers asking the user for location permissions.
 // This won't do anything if the permission is already granted.
 Permissions.askAsync(Permissions.LOCATION);
+
 export default class ExplorePage extends React.Component {
     constructor(props) {
         super(props);
@@ -49,7 +50,6 @@ export default class ExplorePage extends React.Component {
     initialLong = -70.891919;
     initialDelta = 0.005;
     return {
-
       region: {
         latitude: initialLat,
         longitude: initialLong ,
@@ -58,31 +58,10 @@ export default class ExplorePage extends React.Component {
       },
     };
   }
-    componentDidMount() {
-        // if (Platform.OS === 'ios') this.watchID = navigator.geolocation.watchPosition();
-        
-    }
 
-    componentWillUnmount() {
-        // if (Platform.OS === 'ios') navigator.geolocation.clearWatch(this.watchID);
-
-    }
-    componentDidUpdate (){
-      // if (this.props.screenProps.tourStarted){
-
-      //        if(this.markers){
-      //           if(this.markerID){
-      //                 this.markers[this.markerID].showCallout();  
-      //               }
-      //         }
-      //         if( this.props.screenProps.currMarker == Object.keys(this.props.screenProps.murals).length){
-      //             this.toggleTour();
-      //           }
-      //       }
-    }
-    onRegionChange(region) {
-      this.setState({ region });
-    }
+  onRegionChange(region) {
+    this.setState({ region });
+  }
 
   static navigationOptions = ({ navigation}) => {
     return Platform.OS === "ios"
@@ -179,11 +158,6 @@ export default class ExplorePage extends React.Component {
   }
   
   goToMural() {
-
-   
-    // if (this.calloutToMakeVisible) {
-    //   this.calloutToMakeVisible.showCallout();
-    // }
     murals = this.props.screenProps.murals || {};
     if (this.props.screenProps.tourStarted) {
             // See if the currMarker corresponds to a mural
@@ -219,10 +193,6 @@ export default class ExplorePage extends React.Component {
 
   }
 
-
-
-
-
     toggleTour() {
 
       console.log("start button pressed");
@@ -233,12 +203,9 @@ export default class ExplorePage extends React.Component {
         });
         
       }
-      
-      
+
         this.props.screenProps.tourState()
 
-
-      
     
     }
 
@@ -251,12 +218,8 @@ export default class ExplorePage extends React.Component {
         if( this.props.screenProps.currMarker == Object.keys(this.props.screenProps.murals).length - 1){
             this.toggleTour();
         }
-          
-      
 
     }
-
-
 
     getCurrCoordsLat(){
       murals = this.props.screenProps.murals || {}
@@ -269,10 +232,8 @@ export default class ExplorePage extends React.Component {
               Lat = parseFloat(murals[key]["Lat"]);
               return Lat;
             }
-
           })
       
-    
       return Lat;
 
     }
@@ -287,12 +248,8 @@ export default class ExplorePage extends React.Component {
             Lon = parseFloat(murals[key]["Long"]);
             return Lon;
           }
-
         })
-
-
       return Lon;
-
     }
 
     tourPrev() {
@@ -304,7 +261,6 @@ export default class ExplorePage extends React.Component {
       }
     }
     
-
     render() {
         const { navigate } = this.props.navigation;
         initialLat = 42.518217;
@@ -415,31 +371,6 @@ export default class ExplorePage extends React.Component {
     }
 
 }
-
-
-//console.log(this.props.screenProps.currMarker)
-
-      //   Object.keys(murals).map((key,i) =>{
-
-      //     if (murals[key]["Index"] == this.props.screenProps.currMarker){
-      //       Lat = parseFloat(murals[key]["Lat"]);
-      //       Lon = parseFloat(murals[key]["Long"]);
-      //     }
-
-      //   })
-        
-      // console.log(this.props.screenProps.currMarker)
-
-      //    _mapView.animateToCoordinate({
-      //       latitude: Lat,
-      //       longitude: Lon,
-      //     }, 1000)
-// {{
-//                 latitude: this.props.screenProps.tourStarted == false ? initialLat: this.getCurrCoordsLat() ,
-//                 longitude: this.props.screenProps.tourStarted == false ? initialLong : this.getCurrCoordsLong() ,
-//                 latitudeDelta: this.props.screenProps.tourStarted == false ? initialDelta : 0.0001,
-//                 longitudeDelta: this.props.screenProps.tourStarted == false ? initialDelta : 0.0001,
-//               }}
 
 
 /*****************************************************************************/

--- a/PUAMapp/MuralInfoPage.js
+++ b/PUAMapp/MuralInfoPage.js
@@ -133,6 +133,12 @@ export default class MuralInfoPage extends React.Component {
     const mural = this.props.navigation.state.params.mural;
     const artist = this.props.navigation.state.params.artist;
     const { navigate } = this.props.navigation;
+    
+    // Going to the explore page from the mural info page should end the tour.
+    if (this.props.screenProps.tourStarted) {
+        this.props.screenProps.tourState();
+    }
+    
     navigate("ExplorePage", {
         muralID: mural["uuid"]
     });


### PR DESCRIPTION
- remove lots of dead code and unnecessary whitespace
- remove region and markers from ExplorePage state, markers are just part of the class itself now
- markers dictionary instead of a markers array
- remove the dependence on redux to determine if you came from the mural info page, just make a function instead
- rename renderImages to renderMarkers
- make one function that contains all the logic for determining which mural (if any) we'd want to show. This encompasses both the tour and coming from the gallery
- fixes the animation bug when we would do showCallout() before completely animating to the new region
- fixes other itty bitty bugs with the AnimateMapView
- MuralInfoPage is now responsible for ending the tour prior to navigating to the ExplorePage.

Lmk if anything is confusing. See the commits for a more granular change history.

@chris-anderson67 @suruchidev @llevonick 
